### PR TITLE
Configure Firefox settings with Nix

### DIFF
--- a/hosts/rostam/mod/firefox.nix
+++ b/hosts/rostam/mod/firefox.nix
@@ -6,5 +6,24 @@
 }:
 
 {
-  programs.firefox.enable = true;
+  home-manager.users.eudoxia.programs.firefox = {
+    enable = true;
+
+    profiles.default = {
+      id = 0;
+      name = "default";
+      isDefault = true;
+
+      # Firefox preferences (about:config settings)
+      settings = {
+        # Disable "match whole words" in find bar by default
+        "findbar.entireword" = false;
+
+        # Other useful preferences you might want to configure:
+        # "browser.startup.homepage" = "about:blank";
+        # "privacy.trackingprotection.enabled" = true;
+        # "browser.disableResetPrompt" = true;
+      };
+    };
+  };
 }


### PR DESCRIPTION
- Move Firefox configuration to home-manager
- Set up default Firefox profile
- Disable "match whole words" in find bar by default (findbar.entireword = false)