### PR TITLE
Fix i2c group configuration in bright.nix

### DIFF
--- a/hosts/rostam/modules/bright.nix
+++ b/hosts/rostam/modules/bright.nix
@@ -16,7 +16,7 @@
   boot.kernelModules = [ "i2c-dev" ];
 
   # Create the i2c group.
-  users.groups.i2c = {};
+  users.groups.i2c = { };
 
   # Add eudoxia to the i2c group.
   users.users.eudoxia.extraGroups = [ "i2c" ];


### PR DESCRIPTION
Add explicit i2c group definition before adding user to the group. NixOS requires groups to be explicitly created before users can be added to them via extraGroups.