### PR TITLE
Stop auto-creating Desktop and Downloads directories

### DIFF
--- a/nixos/modules/eudoxia.nix
+++ b/nixos/modules/eudoxia.nix
@@ -14,4 +14,10 @@
       "wheel"
     ];
   };
+
+  # Disable automatic creation of XDG user directories
+  home-manager.users.eudoxia.xdg.userDirs = {
+    enable = false;
+    createDirectories = false;
+  };
 }


### PR DESCRIPTION
Prevents home-manager from automatically creating Desktop, Downloads, and other XDG directories by setting xdg.userDirs.enable = false.