### PR TITLE
Fix xscreensaver service dying on logout

### DIFF
--- a/nixos/modules/xscreensaver/default.nix
+++ b/nixos/modules/xscreensaver/default.nix
@@ -12,6 +12,12 @@
     xscreensaver
   ];
 
+  systemd.user.services.xscreensaver = {
+    Service = {
+      Restart = "always";
+    };
+  };
+
   home-manager.users.eudoxia.home.file = {
     ".xscreensaver".source = ./xscreensaver.txt;
   };


### PR DESCRIPTION
Add Restart=always to the xscreensaver user service configuration to ensure it automatically restarts even after logging out of the window manager.