### PR TITLE
Add emote package to NixOS config [fix #26]

### DIFF
--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -27,6 +27,7 @@
         ./modules/desktop.nix
         ./modules/dev.nix
         ./modules/emacs
+        ./modules/emote
         ./modules/espanso
         ./modules/eudoxia.nix
         ./modules/firefox

--- a/nixos/modules/desktop.nix
+++ b/nixos/modules/desktop.nix
@@ -10,7 +10,6 @@
     calibre
     chromium
     djview
-    emote
     evince
     file-roller
     flowtime

--- a/nixos/modules/emote/default.nix
+++ b/nixos/modules/emote/default.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  home-manager.users.eudoxia.home.packages = [ pkgs.emote ];
+
+  home-manager.users.eudoxia.systemd.user.services.emote = {
+    Unit = {
+      Description = "Emote emoji picker";
+      After = [ "graphical-session.target" ];
+      PartOf = [ "graphical-session.target" ];
+    };
+
+    Service = {
+      ExecStart = "${pkgs.emote}/bin/emote";
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}


### PR DESCRIPTION
Create a new module for emote that:
- Installs the emote package
- Configures a systemd user service to start emote automatically on login
- Service starts after graphical-session.target and restarts on failure

This moves emote configuration from desktop.nix into its own dedicated module.