### PR TITLE
Configure Vertco

### DIFF
--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -215,7 +215,11 @@
 
 (use-package vertico
   :init
-  (vertico-mode))
+  (vertico-mode)
+  :config
+  (require 'vertico-directory)
+  :bind (:map vertico-map
+              ("DEL" . vertico-directory-delete-char)))
 
 ;;;
 ;;; Mode: Projectile


### PR DESCRIPTION
Add vertico-directory extension and bind DEL to vertico-directory-delete-char so that backspace erases entire pathname components instead of single characters.