### PR TITLE
Add rust-analyzer to NixOS Emacs config

### DIFF
--- a/modules/emacs/default.nix
+++ b/modules/emacs/default.nix
@@ -16,6 +16,8 @@
           agda2-mode
           i3wm-config-mode
           kaolin-themes
+          lsp-mode
+          lsp-ui
           magit
           markdown-mode
           moe-theme

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -237,6 +237,33 @@
               ("C-c p" . projectile-command-map)))
 
 ;;;
+;;; Mode: LSP
+;;;
+
+(use-package lsp-mode
+  :commands lsp
+  :config
+  ;; Performance tuning
+  (setq lsp-idle-delay 0.500)
+  (setq lsp-log-io nil)
+  ;; Enable which-key integration
+  (setq lsp-keymap-prefix "C-c l")
+  ;; Disable intrusive UI elements
+  (setq lsp-headerline-breadcrumb-enable nil)
+  (setq lsp-lens-enable nil)
+  :hook ((rust-mode . lsp)
+         (lsp-mode . lsp-enable-which-key-integration)))
+
+(use-package lsp-ui
+  :commands lsp-ui-mode
+  :config
+  ;; Configure UI elements
+  (setq lsp-ui-sideline-enable t)
+  (setq lsp-ui-sideline-show-hover nil)
+  (setq lsp-ui-doc-enable t)
+  (setq lsp-ui-doc-position 'at-point))
+
+;;;
 ;;; Mode: Inform7
 ;;;
 

--- a/modules/rust.nix
+++ b/modules/rust.nix
@@ -8,5 +8,6 @@
 {
   home-manager.users.eudoxia.home.packages = with pkgs; [
     rustup
+    rust-analyzer
   ];
 }


### PR DESCRIPTION
This commit adds full rust-analyzer support to the Emacs configuration:

- Add rust-analyzer package to NixOS (modules/rust.nix)
- Add lsp-mode and lsp-ui packages to Emacs (modules/emacs/default.nix)
- Configure LSP mode with rust-mode hook (modules/emacs/init.el)

The LSP configuration includes performance tuning and sensible defaults for the UI elements.